### PR TITLE
Global phone dedupe with audit sheets and CSV export

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -1,0 +1,85 @@
+function _json(o) {
+  return ContentService.createTextOutput(JSON.stringify(o)).setMimeType(ContentService.MimeType.JSON);
+}
+
+function _toCsv(rows) {
+  return (rows || []).map(r =>
+    (r || []).map(v => '"' + String(v ?? "").replace(/"/g, '""') + '"').join(",")
+  ).join("\r\n");
+}
+
+function doGet(e) {
+  return _json({ ok: true, error: "POST only" });
+}
+
+function doPost(e) {
+  try {
+    var data = JSON.parse(e.postData.contents || '{}');
+    if (data.expectedKey && data.key !== data.expectedKey) {
+      return _json({ ok: false, error: 'bad key' });
+    }
+
+    var email = data.email;
+    var title = data.title || 'Planet Scrape';
+    var summaryRows = Array.isArray(data.summaryRows) ? data.summaryRows : [];
+    var allRows = Array.isArray(data.allRows) ? data.allRows : [];
+
+    var ss = SpreadsheetApp.create(title);
+    var id = ss.getId();
+    var url = ss.getUrl();
+
+    var summary = ss.getActiveSheet();
+    summary.setName('Summary');
+    if (summaryRows.length) summary.getRange(1,1,summaryRows.length,summaryRows[0].length).setValues(summaryRows);
+
+    var all = ss.insertSheet('AllNumbers');
+    if (allRows.length) all.getRange(1,1,allRows.length,allRows[0].length).setValues(allRows);
+
+    // Freeze header + bold only actual header width
+    summary.setFrozenRows(1);
+    all.setFrozenRows(1);
+    if (summaryRows.length) summary.getRange(1,1,1,summaryRows[0].length).setFontWeight('bold');
+    if (allRows.length)     all.getRange(1,1,1,allRows[0].length).setFontWeight('bold');
+
+    // Keep first two columns of AllNumbers as text (names + phone)
+    all.getRange(1,1,all.getMaxRows(),2).setNumberFormat('@');
+
+    // Optional: NeedsAreaCode
+    var csvUrl = "";
+    if (Array.isArray(data.needsAreaRows) && data.needsAreaRows.length) {
+      var needs = ss.insertSheet('NeedsAreaCode');
+      needs.getRange(1,1,data.needsAreaRows.length,data.needsAreaRows[0].length).setValues(data.needsAreaRows);
+      needs.setFrozenRows(1);
+      needs.getRange(1,1,1,data.needsAreaRows[0].length).setFontWeight('bold');
+      needs.getRange(1,1,needs.getMaxRows(),2).setNumberFormat('@');
+    }
+
+    // Optional: AllNumbers_Details (audit)
+    if (Array.isArray(data.detailsRows) && data.detailsRows.length) {
+      var det = ss.insertSheet('AllNumbers_Details');
+      det.getRange(1,1,data.detailsRows.length,data.detailsRows[0].length).setValues(data.detailsRows);
+      det.setFrozenRows(1);
+      det.getRange(1,1,1,data.detailsRows[0].length).setFontWeight('bold');
+      // text format first two columns (Name + Phone)
+      det.getRange(1,1,det.getMaxRows(),2).setNumberFormat('@');
+    }
+
+    // ALSO create a CSV for AllNumbers
+    var csvName = title + ' - AllNumbers.csv';
+    var csvBlob = Utilities.newBlob(_toCsv(allRows), 'text/csv', csvName);
+    var csvFile = DriveApp.createFile(csvBlob);
+    csvFile.addViewer(email);
+    csvUrl = csvFile.getUrl();
+
+    // Share sheet with the user and notify
+    DriveApp.getFileById(id).addViewer(email);
+    try {
+      MailApp.sendEmail(email, 'Your Planet files are ready', url + "\n\nCSV: " + csvUrl);
+    } catch (err) {}
+
+    return _json({ ok: true, spreadsheetId: id, url: url, csvUrl: csvUrl });
+  } catch (err) {
+    return _json({ ok: false, error: String(err && err.message ? err.message : err) });
+  }
+}
+

--- a/src/scraper.js
+++ b/src/scraper.js
@@ -266,7 +266,7 @@ async function harvestClickToCall(page){
 
   const before = new Set(await gatherVisibleNumberTokens(page));
   await callBtn.click().catch(()=>{});
-  await page.waitForTimeout(350); // numbers slide down
+  await page.waitForTimeout(800); // numbers slide down
 
   const after  = new Set(await gatherVisibleNumberTokens(page));
   const diff   = Array.from(after).filter(s => !before.has(s));
@@ -567,6 +567,7 @@ async function scrapePlanet({ username, password, maxLeads = 5 }){
       // 2) policies + phones + monthly total (active only)
       const detail = await parseLeadDetail(page);
       if (detail.primaryNameHeader) primaryName = detail.primaryNameHeader || primaryName;
+      if (!primaryName || !primaryName.trim()) primaryName = "(Unknown Lead)";
       policyPhoneRows.push(...detail.policyRows);
 
       // per-lead rollup

--- a/src/server.js
+++ b/src/server.js
@@ -42,6 +42,7 @@ app.post('/scrape', async (req, res) => {
     return res.json({
       ok: true,
       sheetUrl: sheet.url,
+      csvUrl: sheet.csvUrl || null,
       meta: result.meta,
       leadCount: result.meta?.leadCount,
       sumMonthlyAcrossLeads: result.meta?.sumMonthlyAcrossLeads

--- a/src/sheets.js
+++ b/src/sheets.js
@@ -1,19 +1,62 @@
-// src/sheets.js
 const axios = require("axios");
+
+/* ---------- helpers ---------- */
+function digitsOnly(s) { return String(s || "").replace(/\D/g, ""); }
+function isTenDigitUS(r) {
+  const d = digitsOnly(r.rawDigits || r.phone || r.original);
+  return d.length === 10 && r.valid !== false;
+}
+function isSevenDigit(r) {
+  const d = digitsOnly(r.rawDigits || r.phone || r.original);
+  return d.length === 7;
+}
+function normKeyWithExt(r) {
+  const d = digitsOnly(r.rawDigits || r.phone || r.original);
+  const ext = r.extension ? String(r.extension) : "";
+  return `${d}|${ext}`;
+}
 
 /* ---------- row builders ---------- */
 function buildAllNumbersRows(leads) {
   const rows = [["Primary Name", "Phone"]];
+  const seen = new Set();
+
   for (const L of (leads || [])) {
-    const primary = L.primaryName || "";
-    const seen = new Set();
+    const primary = (L.primaryName && String(L.primaryName).trim()) || "(Unknown Lead)";
+
     const push = (r) => {
-      const key = `${r.rawDigits || r.original || r.phone || ""}|${r.extension || ""}`;
+      if (!r) return;
+      if (!isTenDigitUS(r)) return; // drop invalids & 7-digit
+      const key = normKeyWithExt(r);
       if (seen.has(key)) return;
       seen.add(key);
-      const phone = r.phone || r.rawDigits || r.original || "";
-      if (!phone) return;
-      rows.push([primary, String(phone)]); // keep as text
+
+      const out = r.phone || r.rawDigits || r.original || "";
+      if (!out) return;
+      rows.push([primary, String(out)]);
+    };
+
+    (L.clickToCall || []).forEach(push);
+    (L.policyPhones || []).forEach(push);
+  }
+  return rows;
+}
+
+function buildNeedsAreaRows(leads) {
+  const rows = [["Primary Name", "Phone (7-digit)"]];
+  const seen = new Set();
+
+  for (const L of (leads || [])) {
+    const primary = (L.primaryName && String(L.primaryName).trim()) || "(Unknown Lead)";
+    const push = (r) => {
+      if (!r) return;
+      if (!isSevenDigit(r)) return;
+      const key = normKeyWithExt(r);
+      if (seen.has(key)) return;
+      seen.add(key);
+      const out = r.phone || r.rawDigits || r.original || "";
+      if (!out) return;
+      rows.push([primary, String(out)]);
     };
     (L.clickToCall || []).forEach(push);
     (L.policyPhones || []).forEach(push);
@@ -21,49 +64,70 @@ function buildAllNumbersRows(leads) {
   return rows;
 }
 
-function buildSummaryRows(leads) {
-  return [
-    ["Primary Name", "Monthly Special Total", "Star", "ClickToCall Count", "PolicyPhones Count"],
-    ...((leads || []).map((L) => [
-      L.primaryName || "",
-      Number(L.monthlySpecialTotal || 0),
-      L.star || "",
-      (L.clickToCall || []).length,
-      (L.policyPhones || []).length,
-    ])),
-  ];
+function buildDetailsRows(leads) {
+  const rows = [["Primary Name","Phone","Source","Extension","Flags","RawDigits","Original"]];
+  const seen = new Set();
+
+  for (const L of (leads || [])) {
+    const primary = (L.primaryName && String(L.primaryName).trim()) || "(Unknown Lead)";
+    const push = (r) => {
+      if (!r) return;
+      const key = normKeyWithExt(r) + "|" + (r.source || r.lineType || "");
+      if (seen.has(key)) return;
+      seen.add(key);
+      const phoneOut = r.phone || r.rawDigits || r.original || "";
+      rows.push([
+        primary,
+        String(phoneOut || ""),
+        String(r.source || r.lineType || ""),
+        r.extension ? String(r.extension) : "",
+        Array.isArray(r.flags) ? r.flags.join(", ") : String(r.flag || ""),
+        String(r.rawDigits || ""),
+        String(r.original || "")
+      ]);
+    };
+
+    (L.clickToCall || []).forEach(push);
+    (L.policyPhones || []).forEach(push);
+  }
+  return rows;
 }
 
 /* ---------- main entry ---------- */
 exports.createSheetAndShare = async function createSheetAndShare({ email, result }) {
-  // Prefer a pre-resolved echo URL if you set one; else use the /exec URL
   const webappUrl = process.env.GSCRIPT_REAL_URL || process.env.GSCRIPT_WEBAPP_URL;
-  const sharedKey = process.env.GSCRIPT_SHARED_SECRET || ""; // optional
-
-  if (!webappUrl) {
-    throw new Error("Missing GSCRIPT_WEBAPP_URL (or GSCRIPT_REAL_URL) env var");
-  }
+  const sharedKey  = process.env.GSCRIPT_SHARED_SECRET || "";
+  if (!webappUrl) throw new Error("Missing GSCRIPT_WEBAPP_URL (or GSCRIPT_REAL_URL)");
 
   const payload = {
     email,
-    title: `Planet Scrape — ${email} — ${new Date().toISOString().replace("T", " ").slice(0, 19)}`,
-    summaryRows: buildSummaryRows(result.leads),
+    title: `Planet Scrape — ${email} — ${new Date().toISOString().replace("T"," ").slice(0,19)}`,
+    summaryRows: (result && Array.isArray(result.leads)) ? [
+      ["Primary Name","Monthly Special Total","Star","ClickToCall Count","PolicyPhones Count"],
+      ...result.leads.map(L => [
+        (L.primaryName && String(L.primaryName).trim()) || "(Unknown Lead)",
+        Number(L.monthlySpecialTotal || 0),
+        L.star || "",
+        Array.isArray(L.clickToCall) ? L.clickToCall.length : 0,
+        Array.isArray(L.policyPhones) ? L.policyPhones.length : 0,
+      ])
+    ] : [["Primary Name","Monthly Special Total","Star","ClickToCall Count","PolicyPhones Count"]],
     allRows: buildAllNumbersRows(result.leads),
-    ...(sharedKey ? { expectedKey: sharedKey, key: sharedKey } : {}),
+    needsAreaRows: buildNeedsAreaRows(result.leads),
+    detailsRows: buildDetailsRows(result.leads),
+    ...(sharedKey ? { expectedKey: sharedKey, key: sharedKey } : {})
   };
 
-  // Post without following redirects; if 30x, extract Location or parse the HTML and re-post.
   const baseOpts = {
     timeout: 120000,
     headers: { "Content-Type": "application/json" },
     maxRedirects: 0,
-    validateStatus: (s) => s >= 200 && s < 400, // accept 30x
+    validateStatus: s => s >= 200 && s < 400
   };
 
   let data;
   try {
     const r1 = await axios.post(webappUrl, payload, baseOpts);
-
     if (r1.status >= 300 && r1.status < 400) {
       let loc = r1.headers?.location || "";
       if (!loc && r1.data) {
@@ -71,9 +135,7 @@ exports.createSheetAndShare = async function createSheetAndShare({ email, result
         const m = html.match(/https:\/\/script\.googleusercontent\.com\/macros\/echo\?[^"'<> ]+/);
         if (m) loc = m[0].replace(/&amp;/g, "&");
       }
-            if (!loc) throw new Error("Apps Script redirected but no Location found");
-
-      // The echo URL must be fetched with GET (POST will 405)
+      if (!loc) throw new Error("Apps Script redirected but no Location found");
       const r2 = await axios.get(loc, { timeout: 120000 });
       data = r2.data;
     } else {
@@ -89,5 +151,13 @@ exports.createSheetAndShare = async function createSheetAndShare({ email, result
     throw new Error(`Apps Script failed: ${data && data.error ? data.error : "unknown error"}`);
   }
 
-  return { spreadsheetId: data.spreadsheetId, url: data.url };
+  return { spreadsheetId: data.spreadsheetId, url: data.url, csvUrl: data.csvUrl || null };
 };
+
+module.exports = {
+  ...module.exports,
+  buildAllNumbersRows,
+  buildNeedsAreaRows,
+  buildDetailsRows
+};
+


### PR DESCRIPTION
## Summary
- Deduplicate and filter phone lists, separating 10-digit dialables, 7-digit captures, and a detailed audit table.
- Ensure each lead has a fallback name and give click-to-call reveals more time.
- Apps Script now generates optional NeedsAreaCode and AllNumbers_Details sheets and returns CSV download URL.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b7c531bc88832686b55863fa35aec6