### PR TITLE
feat: add SSE endpoint for live scraper logs

### DIFF
--- a/src/scraper.js
+++ b/src/scraper.js
@@ -1,6 +1,11 @@
 // src/scraper.js
 const { chromium } = require("playwright");
 
+function streamLog(msg) {
+  console.log(msg);
+  if (global.__logStream) global.__logStream(msg);
+}
+
 // ---- URLs ----
 const BASE = "https://m.planetaltig.com";
 const LOGIN_URL = `${BASE}/Account/Login`;
@@ -531,6 +536,7 @@ async function goToNextLead(page){
 
 // ---------- main scraper ----------
 async function scrapePlanet({ username, password, maxLeads = 5 }){
+  streamLog(`Starting scrape with max ${maxLeads} leads...`);
   const { browser, context, page } = await launch();
 
   // flattened arrays (kept for convenience / jq examples)
@@ -544,6 +550,7 @@ async function scrapePlanet({ username, password, maxLeads = 5 }){
 
   try{
     await login(page, { username, password });
+    streamLog('Logged in, navigating to leads...');
     await goToAllLeads(page);
 
     // Open the first lead (fallback path if arrowing fails)
@@ -556,6 +563,7 @@ async function scrapePlanet({ username, password, maxLeads = 5 }){
     await sleep(350);
 
     while (leadCount < maxLeads) {
+      streamLog(`Processing lead ${leadCount + 1}`);
       // primary name from header
       let primaryName = await getPrimaryNameFromHeader(page);
 
@@ -593,6 +601,7 @@ async function scrapePlanet({ username, password, maxLeads = 5 }){
       await sleep(300);
     }
 
+    streamLog('Scrape finished.');
     return {
       ok: true,
       leads,                    // per-lead (name, monthly, star, phones)

--- a/src/server.js
+++ b/src/server.js
@@ -15,6 +15,23 @@ const MAX_LEADS_DEFAULT = Number(process.env.MAX_LEADS_DEFAULT || 200);
 // Health endpoint (used by Cloud Run)
 app.get('/health', (_req, res) => res.status(200).send('ok'));
 
+// Live log streaming endpoint using Server-Sent Events (SSE)
+app.get('/logs', async (req, res) => {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.flushHeaders();
+
+  const log = (msg) => res.write(`data: ${msg}\n\n`);
+  global.__logStream = log;
+
+  log('[SSE] Live log stream started...');
+
+  req.on('close', () => {
+    global.__logStream = null;
+  });
+});
+
 // Main scrape endpoint
 app.post('/scrape', async (req, res) => {
   const { username, password, email } = req.body || {};


### PR DESCRIPTION
## Summary
- support live log stream via `/logs` SSE endpoint
- forward scraper logs to SSE clients with `streamLog`
- log scraper progress for real-time monitoring

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b7d44809b8832682eea1cf4b8efda2