### PR TITLE
Add run form and email CSV delivery

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -74,10 +74,15 @@ function doPost(e) {
     // Share sheet with the user and notify
     DriveApp.getFileById(id).addViewer(email);
     try {
-      MailApp.sendEmail(email, 'Your Planet files are ready', url + "\n\nCSV: " + csvUrl);
+      MailApp.sendEmail({
+        to: email,
+        subject: 'Your Planet files are ready',
+        body: url,
+        attachments: [csvBlob]
+      });
     } catch (err) {}
 
-    return _json({ ok: true, spreadsheetId: id, url: url, csvUrl: csvUrl });
+    return _json({ ok: true, sheetUrl: url, csvUrl: csvUrl, spreadsheetId: id, url: url });
   } catch (err) {
     return _json({ ok: false, error: String(err && err.message ? err.message : err) });
   }


### PR DESCRIPTION
## Summary
- serve a lightweight HTML form at GET `/run`
- allow `/scrape` to consume form data and forward email to Apps Script
- Apps Script emails the generated CSV and responds with sheet & CSV links

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7e3967d248326b46131d330ddab4b