### PR TITLE
feat: robust phone normalization + flags, sheet reformat, CSV export, and name normalization

### DIFF
--- a/src/scraper.js
+++ b/src/scraper.js
@@ -1,6 +1,13 @@
 // src/scraper.js
 const { chromium } = require("playwright");
+const fs = require("fs");
 const { createSheetAndShare } = require("./sheets");
+const {
+  normalizePersonName,
+  normalizeAndFlag,
+  dedupePhones,
+  labelWindowAccepts,
+} = require("./utils/phone");
 
 function makeLogger(runId, stream) {
   return (msg) => {
@@ -20,91 +27,6 @@ const PACK_ANCHOR = '/Lead/InboxDetail?LeadId=';
 const sleep = (ms) => new Promise(r => setTimeout(r, ms));
 const nowIso = () => new Date().toISOString();
 const clamp = (n, lo, hi) => Math.min(hi, Math.max(lo, n));
-const toPretty = (d10) => d10 ? `(${d10.slice(0,3)}) ${d10.slice(3,6)}-${d10.slice(6)}` : null;
-
-function sameDigits(s){ return /^([0-9])\1{9}$/.test(s); }
-
-// NANP validation (10 digits)
-function validUS10(d10){
-  if(!d10 || d10.length !== 10) return false;
-  if(sameDigits(d10)) return false;
-  const npa = d10.slice(0,3), nxx = d10.slice(3,6), line = d10.slice(6);
-  if(/[01]/.test(npa[0])) return false; // NPA can’t start 0/1
-  if(/[01]/.test(nxx[0])) return false; // NXX can’t start 0/1
-  // 555-01xx fake block
-  if(npa === '555' && /^01\d\d$/.test(line)) return false;
-  // service codes (211/311/…911) as NPAs: reject
-  if(/^(211|311|411|511|611|711|811|911)$/.test(npa)) return false;
-  return true;
-}
-
-const TOLL_FREE = new Set(["800","888","877","866","855","844","833","822"]);
-
-function normalizePhoneCandidate(raw, contextLabel){
-  // grab extension if present
-  let ext = null;
-  const extMatch = String(raw).match(/\b(?:x|ext\.?|#)\s*([0-9]{2,6})\b/i);
-  if(extMatch) ext = extMatch[1];
-
-  let s = String(raw)
-    .replace(/\b(?:x|ext\.?|#)\s*[0-9]{2,6}\b/ig,'') // remove ext bit
-    .replace(/[^\d+]/g, '');
-
-  // handle +1 or leading 1
-  if(s.startsWith('+1')) s = s.slice(2);
-  if(s.length === 11 && s.startsWith('1')) s = s.slice(1);
-
-  // classify
-  let rawDigits = null, pretty = null, valid = false, flags = [];
-  let tollFree = false, international = false;
-
-  if(s.startsWith('+') && !s.startsWith('+1')){
-    international = true;
-  }
-
-  if(/^\d{10}$/.test(s)){
-    rawDigits = s;
-    valid = validUS10(s);
-    pretty = valid ? toPretty(s) : null;
-    if(TOLL_FREE.has(s.slice(0,3))) { tollFree = true; }
-  }else if(/^\d{7}$/.test(s)){
-    rawDigits = s;
-    flags.push("Needs Area Code");
-  }else{
-    // reject weird lengths
-    return null;
-  }
-
-  // context flags (label/source)
-  if(contextLabel && /fax/i.test(contextLabel)) flags.push("Fax");
-  if(international) flags.push("International");
-  if(ext) flags.push("Has Extension");
-  if(tollFree) flags.push("Toll-free kept");
-
-  return {
-    original: String(raw),
-    rawDigits,
-    phone: pretty,
-    extension: ext,
-    valid,
-    tollFree,
-    international,
-    flags
-  };
-}
-
-function uniqBy(arr, keyFn){
-  const seen = new Set();
-  const out = [];
-  for(const x of arr){
-    const k = keyFn(x);
-    if(!seen.has(k)){
-      seen.add(k);
-      out.push(x);
-    }
-  }
-  return out;
-}
 
 async function firstVisible(locator){
   const n = await locator.count();
@@ -326,6 +248,25 @@ async function gatherVisibleNumberTokens(page){
   }, TOKEN_RE.source);
 }
 
+function buildCompactCsv(rows){
+  const byName = new Map();
+  for (const r of rows) {
+    if (r.status !== 'ok') continue;
+    const name = r.primaryName || '';
+    const key = `${r.rawDigits || ''}#${r.extension || ''}`;
+    if (!byName.has(name)) byName.set(name, new Map());
+    const map = byName.get(name);
+    if (!map.has(key)) map.set(key, r.pretty || r.rawDigits || r.phone || '');
+  }
+  const lines = ['"Primary Name","Phones"'];
+  for (const [name, map] of byName.entries()) {
+    const phones = Array.from(map.values()).join(', ');
+    const esc = (s) => String(s).replace(/"/g, '""');
+    lines.push(`"${esc(name)}","${esc(phones)}"`);
+  }
+  return lines.join('\n');
+}
+
 // ---------- harvest Click-to-Call by “diffing” before/after click ----------
 async function harvestClickToCall(page, log){
   const rows = [];
@@ -344,30 +285,12 @@ async function harvestClickToCall(page, log){
   const after  = new Set(await gatherVisibleNumberTokens(page));
   const diff   = Array.from(after).filter(s => !before.has(s));
 
-  const seen = new Set();
   for (const token of diff) {
-    const norm = normalizePhoneCandidate(token, "ClickToCall");
-    if (!norm) continue;
-    const key = `${norm.rawDigits || norm.original}-${norm.extension||""}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-
-    rows.push({
-      primaryName: null,            // filled by caller
-      source: "click2call",
-      lineType: "ClickToCall",
-      original: norm.original,
-      rawDigits: norm.rawDigits,
-      phone: norm.phone,
-      extension: norm.extension || null,
-      tollFree: !!norm.tollFree,
-      international: !!norm.international,
-      valid: !!norm.valid,
-      flag: norm.flags.join(", ")
-    });
+    const norm = normalizeAndFlag(token, { from: 'click', inPdfLabelWindow: true });
+    rows.push({ ...norm, source: 'click', label: '' });
   }
 
-  return uniqBy(rows, r => `${r.rawDigits || r.original}-${r.extension||""}`);
+  return dedupePhones(rows);
 }
 
 // ---------- expand all policies ("More" -> "Less") ----------
@@ -412,6 +335,24 @@ async function getPrimaryNameFromHeader(page){
     return cands.length ? cands[0].t : null;
   });
   return name || null;
+}
+
+async function getCityStateZip(page){
+  const txt = await page.evaluate(() => {
+    const cands = Array.from(document.querySelectorAll('body *'))
+      .map(el => (el.textContent || '').trim())
+      .filter(t => /,\s*[A-Za-z]{2,}\s*,?\s*\d{5}/.test(t));
+    return cands.length ? cands[0] : '';
+  });
+  let city = '', state = '', zip = '';
+  if (txt) {
+    const parts = txt.split(',');
+    city = (parts[0] || '').trim();
+    state = (parts[1] || '').trim();
+    const m = String(txt).match(/(\d{5})/);
+    zip = m ? m[1] : '';
+  }
+  return { city, state, zip };
 }
 
 // ---------- parse all policy blocks & phones; compute monthly total (active only) ----------
@@ -484,28 +425,13 @@ async function parseLeadDetail(page){
   // ---- collect policy phones (Ph:/Sec Ph:) from DOM AND from each policy text block ----
   const policyRows = [];
   const seen = new Set();
-  const pushPolicyNumber = (token, label, primaryName) => {
-    const norm = normalizePhoneCandidate(token, label);
-    if (!norm) return;
-    const key = `${norm.rawDigits || norm.original}-${norm.extension || ''}`;
+  const pushPolicyNumber = (token, label) => {
+    const windowText = `${label || ''} ${token}`;
+    const norm = normalizeAndFlag(token, { from: 'pdf', inPdfLabelWindow: labelWindowAccepts(windowText) });
+    const key = `${norm.digits || ''}-${norm.extension || ''}`;
     if (seen.has(key)) return;
     seen.add(key);
-    policyRows.push({
-      primaryName,
-      source: "policy",
-      lineType: /sec/i.test(label) ? "Secondary" :
-                /cell/i.test(label) ? "Cell" :
-                /home/i.test(label) ? "Home" :
-                /work/i.test(label) ? "Work" : "Policy",
-      original: norm.original,
-      rawDigits: norm.rawDigits,
-      phone: norm.phone,
-      extension: norm.extension || null,
-      tollFree: !!norm.tollFree,
-      international: !!norm.international,
-      valid: !!norm.valid,
-      flag: norm.flags.join(", ")
-    });
+    policyRows.push({ ...norm, source: 'pdf', label: label || '' });
   };
 
   // A) same-line label forms inside each policy text block (handles "Ph: 555…  Sec Ph: 444…")
@@ -520,7 +446,7 @@ async function parseLeadDetail(page){
       const tokRe = new RegExp(blockTokenReSrc, 'gi');
       let t;
       while ((t = tokRe.exec(span))) {
-        pushPolicyNumber(t[0], label, primaryNameHeader || null);
+        pushPolicyNumber(t[0], label);
       }
     }
   }
@@ -569,7 +495,7 @@ async function parseLeadDetail(page){
   for (const { label, strings } of domPairs) {
     for (const s of strings) {
       tokenRe.lastIndex = 0;
-      let m; while ((m = tokenRe.exec(s))) pushPolicyNumber(m[0], label, primaryNameHeader || null);
+      let m; while ((m = tokenRe.exec(s))) pushPolicyNumber(m[0], label);
     }
   }
 
@@ -610,13 +536,8 @@ async function scrapePlanet({ username, password, email, maxLeads = 5, runId, st
   const { browser, context, page } = await launch();
 
   // flattened arrays (kept for convenience / jq examples)
-  const clickToCallRows = [];
-  const policyPhoneRows = [];
-
-  // per-lead results
-  const leads = [];
+  const allRows = [];
   let leadCount = 0;
-  let sumAllLeadsMonthly = 0;
 
   try{
     await login(page, { username, password }, log);
@@ -637,60 +558,69 @@ async function scrapePlanet({ username, password, email, maxLeads = 5, runId, st
     while (leadCount < maxLeads) {
       await dismissAnyModal(page, log);
       log(`Processing lead ${leadCount + 1}`);
-      // primary name from header
-      let primaryName = await getPrimaryNameFromHeader(page);
 
-      // 1) click-to-call
-      const c2c = await harvestClickToCall(page, log);
-      c2c.forEach(r => (r.primaryName = primaryName || r.primaryName));
-      clickToCallRows.push(...c2c);
+      const leadUrl = page.url();
+      const leadIdMatch = leadUrl.match(/LeadId=(\d+)/i);
+      const leadId = leadIdMatch ? leadIdMatch[1] : '';
 
-      // 2) policies + phones + monthly total (active only)
+      let primaryNameRaw = await getPrimaryNameFromHeader(page);
+      let primaryName = normalizePersonName(primaryNameRaw || '') || '(Unknown Lead)';
+
+      const { city, state, zip } = await getCityStateZip(page);
+
+      const clickItems = await harvestClickToCall(page, log);
       const detail = await parseLeadDetail(page);
-      if (detail.primaryNameHeader) primaryName = detail.primaryNameHeader || primaryName;
-      if (!primaryName || !primaryName.trim()) primaryName = "(Unknown Lead)";
-      policyPhoneRows.push(...detail.policyRows);
+      const pdfItems = detail.policyRows || [];
 
-      // per-lead rollup
-      const leadMonthly = Number(detail.monthlyTotalActive.toFixed(2));
-      const leadStar = leadMonthly > 100 ? "⭐" : "";
-      leads.push({
-        primaryName: primaryName || null,
-        monthlySpecialTotal: leadMonthly,
-        star: leadStar,
-        clickToCall: c2c,
-        policyPhones: detail.policyRows
-      });
+      // Override primary name if detail has a better header
+      if (detail.primaryNameHeader) {
+        primaryName = normalizePersonName(detail.primaryNameHeader) || primaryName;
+      }
 
-      sumAllLeadsMonthly += leadMonthly;
+      const clickSet = new Set(clickItems.map(i => `${i.digits || ''}#${i.extension || ''}`));
+      const policyExtra = pdfItems.filter(i => !clickSet.has(`${i.digits || ''}#${i.extension || ''}`));
+
+      const clickCount = clickItems.length;
+      const policyExtraCount = policyExtra.length;
+
+      const combined = dedupePhones([...clickItems, ...pdfItems]);
+      for (const item of combined) {
+        const flags = [...(item.flags || [])];
+        if (item.status === 'discard') flags.push('Discard');
+        allRows.push({
+          leadId,
+          primaryName,
+          phone: item.pretty || item.digits,
+          pretty: item.pretty || item.digits,
+          rawDigits: item.digits || '',
+          extension: item.extension || '',
+          flags: flags.join(', '),
+          status: item.status,
+          source: item.source,
+          label: item.label || '',
+          city,
+          state,
+          zip,
+          clickCount,
+          policyExtraCount,
+        });
+      }
+
       leadCount++;
-
       if (leadCount >= maxLeads) break;
-
-      // try right-arrow to next lead; if none, stop
       const moved = await goToNextLead(page, log);
       if (!moved) break;
-
       await sleep(300);
     }
 
-    const result = {
-      ok: true,
-      leads,                    // per-lead (name, monthly, star, phones)
-      // flattened for quick jq/testing:
-      clickToCall: clickToCallRows,
-      policyPhones: policyPhoneRows,
-      meta: {
-        ts: nowIso(),
-        leadCount,
-        sumMonthlyAcrossLeads: Number(sumAllLeadsMonthly.toFixed(2))
-      }
-    };
+    const result = { ok: true, allRows, meta: { ts: nowIso(), leadCount } };
 
     let sheet = null;
     if (email) {
-      // Include email when calling Apps Script so it can deliver results
-      const payload = { email, result };
+      const csvString = buildCompactCsv(allRows);
+      const csvPath = '/tmp/leads.csv';
+      require('fs').writeFileSync(csvPath, csvString, 'utf8');
+      const payload = { email, result: { allRows }, csvData: csvString };
       sheet = await createSheetAndShare(payload);
     }
 
@@ -701,14 +631,7 @@ async function scrapePlanet({ username, password, email, maxLeads = 5, runId, st
     log('Scrape finished.');
 
     if (sheet) {
-      return {
-        ok: true,
-        sheetUrl: sheet.url,
-        csvUrl: sheet.csvUrl || null,
-        meta: result.meta,
-        leadCount: result.meta.leadCount,
-        sumMonthlyAcrossLeads: result.meta.sumMonthlyAcrossLeads
-      };
+      return { ok: true, sheetUrl: sheet.url, csvUrl: sheet.csvUrl || null, meta: result.meta, leadCount: result.meta.leadCount };
     }
 
     return result;

--- a/src/sheets.js
+++ b/src/sheets.js
@@ -1,100 +1,37 @@
 const axios = require("axios");
 
-/* ---------- helpers ---------- */
-function digitsOnly(s) { return String(s || "").replace(/\D/g, ""); }
-function isTenDigitUS(r) {
-  const d = digitsOnly(r.rawDigits || r.phone || r.original);
-  return d.length === 10 && r.valid !== false;
-}
-function isSevenDigit(r) {
-  const d = digitsOnly(r.rawDigits || r.phone || r.original);
-  return d.length === 7;
-}
-function normKeyWithExt(r) {
-  const d = digitsOnly(r.rawDigits || r.phone || r.original);
-  const ext = r.extension ? String(r.extension) : "";
-  return `${d}|${ext}`;
-}
+function buildAllNumbersSheet(allRows) {
+  const header = [
+    "⭐", "Primary Name", "Favorite",
+    "ClickToCall Count", "PolicyPhone Count",
+    "Phone", "Pretty", "RawDigits", "Extension",
+    "Flags", "Source", "Label", "LeadId",
+    "City", "State", "Zip"
+  ];
 
-/* ---------- row builders ---------- */
-function buildAllNumbersRows(leads) {
-  const rows = [["Primary Name", "Phone"]];
-  const seen = new Set();
+  const rows = (allRows || []).map(r => ([
+    "",
+    r.primaryName || "",
+    "",
+    r.clickCount ?? 0,
+    r.policyExtraCount ?? 0,
+    r.phone || r.pretty || r.rawDigits || "",
+    r.pretty || "",
+    r.rawDigits || "",
+    r.extension || "",
+    r.flags || "",
+    r.source || "",
+    r.label || "",
+    String(r.leadId || ""),
+    r.city || "",
+    r.state || "",
+    r.zip || ""
+  ]));
 
-  for (const L of (leads || [])) {
-    const primary = (L.primaryName && String(L.primaryName).trim()) || "(Unknown Lead)";
-
-    const push = (r) => {
-      if (!r) return;
-      if (!isTenDigitUS(r)) return; // drop invalids & 7-digit
-      const key = normKeyWithExt(r);
-      if (seen.has(key)) return;
-      seen.add(key);
-
-      const out = r.phone || r.rawDigits || r.original || "";
-      if (!out) return;
-      rows.push([primary, String(out)]);
-    };
-
-    (L.clickToCall || []).forEach(push);
-    (L.policyPhones || []).forEach(push);
-  }
-  return rows;
+  return [header, ...rows];
 }
 
-function buildNeedsAreaRows(leads) {
-  const rows = [["Primary Name", "Phone (7-digit)"]];
-  const seen = new Set();
-
-  for (const L of (leads || [])) {
-    const primary = (L.primaryName && String(L.primaryName).trim()) || "(Unknown Lead)";
-    const push = (r) => {
-      if (!r) return;
-      if (!isSevenDigit(r)) return;
-      const key = normKeyWithExt(r);
-      if (seen.has(key)) return;
-      seen.add(key);
-      const out = r.phone || r.rawDigits || r.original || "";
-      if (!out) return;
-      rows.push([primary, String(out)]);
-    };
-    (L.clickToCall || []).forEach(push);
-    (L.policyPhones || []).forEach(push);
-  }
-  return rows;
-}
-
-function buildDetailsRows(leads) {
-  const rows = [["Primary Name","Phone","Source","Extension","Flags","RawDigits","Original"]];
-  const seen = new Set();
-
-  for (const L of (leads || [])) {
-    const primary = (L.primaryName && String(L.primaryName).trim()) || "(Unknown Lead)";
-    const push = (r) => {
-      if (!r) return;
-      const key = normKeyWithExt(r) + "|" + (r.source || r.lineType || "");
-      if (seen.has(key)) return;
-      seen.add(key);
-      const phoneOut = r.phone || r.rawDigits || r.original || "";
-      rows.push([
-        primary,
-        String(phoneOut || ""),
-        String(r.source || r.lineType || ""),
-        r.extension ? String(r.extension) : "",
-        Array.isArray(r.flags) ? r.flags.join(", ") : String(r.flag || ""),
-        String(r.rawDigits || ""),
-        String(r.original || "")
-      ]);
-    };
-
-    (L.clickToCall || []).forEach(push);
-    (L.policyPhones || []).forEach(push);
-  }
-  return rows;
-}
-
-/* ---------- main entry ---------- */
-exports.createSheetAndShare = async function createSheetAndShare({ email, result }) {
+exports.createSheetAndShare = async function createSheetAndShare({ email, result, csvData }) {
   const webappUrl = process.env.GSCRIPT_REAL_URL || process.env.GSCRIPT_WEBAPP_URL;
   const sharedKey  = process.env.GSCRIPT_SHARED_SECRET || "";
   if (!webappUrl) throw new Error("Missing GSCRIPT_WEBAPP_URL (or GSCRIPT_REAL_URL)");
@@ -102,19 +39,8 @@ exports.createSheetAndShare = async function createSheetAndShare({ email, result
   const payload = {
     email,
     title: `Planet Scrape — ${email} — ${new Date().toISOString().replace("T"," ").slice(0,19)}`,
-    summaryRows: (result && Array.isArray(result.leads)) ? [
-      ["Primary Name","Monthly Special Total","Star","ClickToCall Count","PolicyPhones Count"],
-      ...result.leads.map(L => [
-        (L.primaryName && String(L.primaryName).trim()) || "(Unknown Lead)",
-        Number(L.monthlySpecialTotal || 0),
-        L.star || "",
-        Array.isArray(L.clickToCall) ? L.clickToCall.length : 0,
-        Array.isArray(L.policyPhones) ? L.policyPhones.length : 0,
-      ])
-    ] : [["Primary Name","Monthly Special Total","Star","ClickToCall Count","PolicyPhones Count"]],
-    allRows: buildAllNumbersRows(result.leads),
-    needsAreaRows: buildNeedsAreaRows(result.leads),
-    detailsRows: buildDetailsRows(result.leads),
+    allRows: buildAllNumbersSheet(result.allRows || []),
+    csvData,
     ...(sharedKey ? { expectedKey: sharedKey, key: sharedKey } : {})
   };
 
@@ -153,11 +79,3 @@ exports.createSheetAndShare = async function createSheetAndShare({ email, result
 
   return { spreadsheetId: data.spreadsheetId, url: data.url, csvUrl: data.csvUrl || null };
 };
-
-module.exports = {
-  ...module.exports,
-  buildAllNumbersRows,
-  buildNeedsAreaRows,
-  buildDetailsRows
-};
-

--- a/src/utils/phone.js
+++ b/src/utils/phone.js
@@ -1,0 +1,179 @@
+const SERVICE_NPA = new Set(["211","311","411","511","611","711","811","911"]);
+const TOLL_FREE_NPA = new Set(["800","888","877","866","855","844","833","822"]);
+const PLACEHOLDER_SET = new Set(["0000000000", "1111111111", "1234567890", "9999999999"]);
+
+function titleCaseWord(w) {
+  if (!w) return w;
+  return w[0].toUpperCase() + w.slice(1).toLowerCase();
+}
+
+function normalizePersonName(name) {
+  if (!name) return "";
+  let n = name.trim();
+
+  // Common "LAST, FIRST [MIDDLE]" in all caps → "First [Middle] Last"
+  if (n.includes(",")) {
+    const [last, rest] = n.split(",", 2);
+    const parts = rest.trim().split(/\s+/).filter(Boolean).map(titleCaseWord);
+    return [...parts, titleCaseWord(last.trim())].join(" ").trim();
+  }
+
+  // Otherwise title-case tokens
+  return n.split(/\s+/).map(titleCaseWord).join(" ").trim();
+}
+
+function onlyDigitsPlus(s) {
+  return String(s || "").replace(/[^\d+]/g, "");
+}
+
+function splitExtension(s) {
+  const m = String(s || "").match(/\b(?:ext\.?|x|#)\s*([0-9]{1,6})\b/i);
+  return m ? m[1] : "";
+}
+
+function cleanToDigitsWithPossiblePlus(s) {
+  return onlyDigitsPlus(s);
+}
+
+function stripToCanonical(raw) {
+  // Remove everything except digits; keep possible leading '+'
+  let cleaned = cleanToDigitsWithPossiblePlus(raw);
+  // Pull out extension separately first (we’ll pass extension back up)
+  const ext = splitExtension(raw);
+
+  // Normalize country code:
+  // +1XXXXXXXXXX → 10 digits
+  // 1XXXXXXXXXX  → drop leading 1
+  // else keep digits
+  let digits = cleaned.replace(/[^\d]/g, "");
+  if (digits.length === 11 && digits[0] === "1") digits = digits.slice(1);
+  if (digits.startsWith("+1") && digits.length === 12) digits = digits.slice(2);
+  return { digits, extension: ext };
+}
+
+function isAllSameDigits(d) {
+  return /^(\d)\1{9}$/.test(d);
+}
+
+function isValidNANP10(d) {
+  if (!/^\d{10}$/.test(d)) return false;
+  const npa = d.slice(0,3);
+  const nxx = d.slice(3,6);
+
+  // Area code 2–9 and not service NPA
+  if (!/^[2-9]/.test(npa)) return false;
+  if (SERVICE_NPA.has(npa)) return false;
+
+  // Central office 2–9
+  if (!/^[2-9]/.test(nxx)) return false;
+
+  // No reserved fake block 555-01xx
+  if (npa === "555" && /^01/.test(nxx)) return false;
+
+  if (PLACEHOLDER_SET.has(d)) return false;
+  if (isAllSameDigits(d)) return false;
+
+  return true;
+}
+
+function isTollFree(d) {
+  if (!/^\d{10}$/.test(d)) return false;
+  return TOLL_FREE_NPA.has(d.slice(0,3));
+}
+
+function pretty10(d) {
+  if (!/^\d{10}$/.test(d)) return d;
+  return `(${d.slice(0,3)}) ${d.slice(3,6)}-${d.slice(6)}`;
+}
+
+/**
+ * Label-aware candidate acceptance for PDFs. Only accept when near a phone label.
+ * Provide a "windowText" that includes the labeled context (same line or neighbor lines).
+ */
+function labelWindowAccepts(windowText) {
+  const t = (windowText || "").toLowerCase();
+  const labels = [
+    "ph", "phone", "cell", "home", "work", "secondary", "sec ph", "tel", "telephone"
+  ];
+  return labels.some(k => t.includes(k));
+}
+
+/**
+ * Main normalization + flags
+ * Returns { rawText, digits, pretty, extension, flags[], status }
+ *  status ∈ { 'ok', 'review', 'discard' }
+ */
+function normalizeAndFlag(rawText, { from = "unknown", inPdfLabelWindow = false } = {}) {
+  const flags = new Set();
+  const { digits, extension } = stripToCanonical(rawText);
+
+  // DO NOT CALL / DNC early
+  if (/\b(do[\s-]?not[\s-]?call|dnc)\b/i.test(rawText)) {
+    flags.add("DNC label");
+  }
+
+  // Too short/long after cleaning
+  if (digits.length < 7 || digits.length > 11) {
+    flags.add("Invalid length");
+    return { rawText, digits, pretty: digits, extension, flags: [...flags], status: "discard" };
+  }
+
+  // 7-digits → keep for review
+  if (digits.length === 7) {
+    flags.add("Needs Area Code");
+    return { rawText, digits, pretty: digits, extension, flags: [...flags], status: "review" };
+  }
+
+  // Now expect 10 digits
+  if (digits.length === 10) {
+    // Filter junk-like patterns in PDF context
+    if (from === "pdf" && !inPdfLabelWindow) {
+      flags.add("Unlabeled number");
+      // keep for review (or flip to discard if you prefer)
+      return { rawText, digits, pretty: pretty10(digits), extension, flags: [...flags], status: "review" };
+    }
+
+    // Obvious fakes / NANP checks
+    if (!isValidNANP10(digits)) {
+      flags.add("NANP invalid");
+      return { rawText, digits, pretty: pretty10(digits), extension, flags: [...flags], status: "discard" };
+    }
+
+    // Toll-free as optional keep
+    if (isTollFree(digits)) {
+      flags.add("Toll-free");
+    }
+
+    if (extension) flags.add("Has Extension");
+
+    return { rawText, digits, pretty: pretty10(digits), extension, flags: [...flags], status: flags.has("Unlabeled number") ? "review" : "ok" };
+  }
+
+  // 11 (already handled "1" trimming above); if we get here, treat as discard.
+  flags.add("Invalid length");
+  return { rawText, digits, pretty: digits, extension, flags: [...flags], status: "discard" };
+}
+
+/**
+ * Dedupe by digits+extension
+ */
+function dedupePhones(items) {
+  const seen = new Set();
+  const out = [];
+  for (const it of items) {
+    const key = `${it.digits || ""}#${it.extension || ""}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(it);
+  }
+  return out;
+}
+
+module.exports = {
+  normalizePersonName,
+  normalizeAndFlag,
+  dedupePhones,
+  pretty10,
+  labelWindowAccepts,
+  isValidNANP10,
+};


### PR DESCRIPTION
## Summary
- add comprehensive phone normalization utilities with NANP validation and labeling
- collect numbers from click-to-call and PDFs with per-lead metadata and counts
- reformat AllNumbers sheet, generate compact CSV, and send with sheet link

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check src/utils/phone.js`
- `node --check src/scraper.js`
- `node --check src/sheets.js`


------
https://chatgpt.com/codex/tasks/task_e_68b7f690aa148326ae0a063f8b71d4aa