### PR TITLE
Load environment variables

### DIFF
--- a/scripts/test-scrape.sh
+++ b/scripts/test-scrape.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Load .env into this shell (supports special chars like ! in passwords)
+if [[ -f .env ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env
+  set +a
+fi
+
+: "${PLANET_USERNAME:?Set PLANET_USERNAME in .env}"
+: "${PLANET_PASSWORD:?Set PLANET_PASSWORD in .env}"
+: "${REPORT_EMAIL:?Set REPORT_EMAIL in .env}"
+
+curl -sS -X POST http://localhost:8080/scrape \
+  -H 'Content-Type: application/json' \
+  -d "{
+        \"username\": \"${PLANET_USERNAME}\",
+        \"password\": \"${PLANET_PASSWORD}\",
+        \"email\":    \"${REPORT_EMAIL}\"
+      }"

--- a/src/server.js
+++ b/src/server.js
@@ -1,3 +1,9 @@
+// Load .env for local/Codespaces runs
+require('dotenv').config();
+if (!process.env.GSCRIPT_WEBAPP_URL) {
+  console.log('⚠️  GSCRIPT_WEBAPP_URL is not set (check your .env).');
+}
+
 const express = require('express');
 const bodyParser = require('body-parser');
 const { scrapePlanet } = require('./scraper');


### PR DESCRIPTION
## Summary
- load env from `.env` on server boot
- add test helper script to populate credentials from `.env`

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b8aeba8e308326b7934a2d091f5c34