### PR TITLE
feat: enhance scraping and sheet output

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -15,7 +15,7 @@ function doPost(e) {
                  new Date().toISOString().replace("T"," ").slice(0,19));
 
     var summaryRows = data.summaryRows || [["Primary Name","Monthly Special Total","Star","ClickToCall Count","PolicyPhones Count"]];
-    var allRows     = data.allRows     || [["Primary Name","Phone"]];
+    var allRows     = data.allRows     || [["Primary Name","Phone","Primary Name (Needs Area Code)","Phone (Needs Area Code)"]];
 
     // Create spreadsheet with Summary + AllNumbers
     var ss = SpreadsheetApp.create(title);
@@ -41,8 +41,8 @@ function doPost(e) {
     summary.getRange(1,1,1,summary.getMaxColumns()).setFontWeight("bold");
     all.getRange(1,1,1,all.getMaxColumns()).setFontWeight("bold");
 
-    // Text format for both columns on AllNumbers
-    all.getRange(1,1,all.getMaxRows(),2).setNumberFormat("@");
+    // Text format for all columns on AllNumbers (4 cols)
+    all.getRange(1,1,all.getMaxRows(),4).setNumberFormat("@");
 
     // Share with the user and notify
     DriveApp.getFileById(id).addViewer(email);


### PR DESCRIPTION
## Summary
- add debug logging, DNC filtering, and pagination to scraper
- expand policy parsing and star rules, classify phone numbers
- restructure AllNumbers sheet into separate valid and 7-digit columns

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check src/scraper.js`
- `node --check src/sheets.js`
- `node --check Code.gs` *(fails: Unknown file extension ".gs")*

------
https://chatgpt.com/codex/tasks/task_e_68b8d796c09883269204ca7693f0951b