### PR TITLE
feat: enhance sheet rendering

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -1,3 +1,24 @@
+// ---- name normalization helpers ----
+function toTitleCase_(s) {
+  if (!s) return '';
+  return String(s)
+    .toLowerCase()
+    .replace(/\b([a-z])/g, (m) => m.toUpperCase());
+}
+
+function normalizeLeadName_(name) {
+  if (!name) return '';
+  const str = String(name).trim();
+  const m = str.match(/^([^,]+),\s*(.+)$/); // LAST, FIRST
+  if (m) {
+    const last = toTitleCase_(m[1]);
+    const first = toTitleCase_(m[2]);
+    return `${first} ${last}`;
+  }
+  return toTitleCase_(str);
+}
+// ------------------------------------
+
 /** Webhook to build + share the Planet sheet */
 function doPost(e) {
   try {
@@ -14,35 +35,22 @@ function doPost(e) {
     var title = data.title || ("Planet Scrape — " + email + " — " +
                  new Date().toISOString().replace("T"," ").slice(0,19));
 
-    var summaryRows = data.summaryRows || [["Primary Name","Monthly Special Total","Star","ClickToCall Count","PolicyPhones Count"]];
-    var allRows     = data.allRows     || [["Primary Name","Phone","Primary Name","Number","Flag"]];
+    var summaryRows    = data.summaryRows    || [];
+    var goodNumbers    = data.goodNumbers    || [];
+    var flaggedNumbers = data.flaggedNumbers || [];
 
     // Create spreadsheet with Summary + AllNumbers
     var ss = SpreadsheetApp.create(title);
     var url = ss.getUrl();
     var id  = ss.getId();
 
+    // Rename default sheet to Summary
+    var firstSheet = ss.getSheets()[0];
+    firstSheet.setName("Summary");
+
     // Build sheets
-    var summary = ss.getSheets()[0]; // default Sheet1
-    summary.setName("Summary");
-    var all = ss.insertSheet("AllNumbers");
-
-    // Write data
-    if (summaryRows.length) {
-      summary.getRange(1,1,summaryRows.length,summaryRows[0].length).setValues(summaryRows);
-    }
-    if (allRows.length) {
-      all.getRange(1,1,allRows.length,allRows[0].length).setValues(allRows);
-    }
-
-    // Freeze header + bold
-    summary.setFrozenRows(1);
-    all.setFrozenRows(1);
-    summary.getRange(1,1,1,summary.getMaxColumns()).setFontWeight("bold");
-    all.getRange(1,1,1,all.getMaxColumns()).setFontWeight("bold");
-
-    // Text format for all five columns on AllNumbers
-    all.getRange(1,1,all.getMaxRows(),5).setNumberFormat("@");
+    renderSummarySheet_(ss, summaryRows);
+    renderAllNumbersSheet_(ss, goodNumbers, flaggedNumbers);
 
     // Share with the user and notify
     DriveApp.getFileById(id).addViewer(email);
@@ -52,6 +60,64 @@ function doPost(e) {
   } catch (err) {
     return _json({ ok: false, error: String(err && err.message || err) }, 500);
   }
+}
+
+function renderSummarySheet_(ss, summaryRows) {
+  // summaryRows is an array of objects: { name, badge, monthlySpecial, clickToCallCount, extraPolicyPhonesCount }
+  const sheet = ss.getSheetByName('Summary') || ss.insertSheet('Summary');
+  sheet.clearContents();
+
+  const headers = ["Badge","Lead","Total Premium","Listed #s","Added #s"];
+  sheet.getRange(1,1,1,headers.length).setValues([headers]);
+
+  // Normalize name + map to the new column order
+  const values = (summaryRows || []).map(r => ([
+    r.badge || "",
+    normalizeLeadName_(r.name || ""),
+    Number(r.monthlySpecial || 0),
+    Number(r.clickToCallCount || 0),
+    Number(r.extraPolicyPhonesCount || 0)
+  ]));
+
+  if (values.length) {
+    sheet.getRange(2,1,values.length,headers.length).setValues(values);
+  }
+
+  // Currency format for Total Premium (column C)
+  if (sheet.getLastRow() >= 2) {
+    sheet.getRange(2,3, sheet.getLastRow()-1, 1).setNumberFormat("$#,##0.00");
+  }
+
+  sheet.setFrozenRows(1);
+  sheet.autoResizeColumns(1, headers.length);
+}
+
+function renderAllNumbersSheet_(ss, goodNumbers, flaggedNumbers) {
+  // goodNumbers: [{name, phone}]
+  // flaggedNumbers: [{name, phone, flag}]
+  const sheet = ss.getSheetByName('AllNumbers') || ss.insertSheet('AllNumbers');
+  sheet.clearContents();
+
+  const headers = ["Lead","Phone","Lead","Number","Flag"];
+  sheet.getRange(1,1,1,headers.length).setValues([headers]);
+
+  const good = (goodNumbers || [])
+    .filter(g => g && g.phone)
+    .map(g => [ normalizeLeadName_(g.name || ""), g.phone || "" ]);
+
+  const flagged = (flaggedNumbers || [])
+    .filter(f => f && f.phone)
+    .map(f => [ normalizeLeadName_(f.name || ""), f.phone || "", f.flag || "" ]);
+
+  if (good.length) {
+    sheet.getRange(2, 1, good.length, 2).setValues(good); // A:B
+  }
+  if (flagged.length) {
+    sheet.getRange(2, 3, flagged.length, 3).setValues(flagged); // C:D:E
+  }
+
+  sheet.setFrozenRows(1);
+  sheet.autoResizeColumns(1, headers.length);
 }
 
 function _json(obj, code) {


### PR DESCRIPTION
## Summary
- normalize lead names with title-casing and `LAST, FIRST` conversion
- render Summary sheet with new column order and currency formatting
- render AllNumbers sheet without spacer rows and with normalized names

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b90c5dbbe4832694ca96df7fe14e37