### PR TITLE
Allow optional sheet sharing via email in Apps Script

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -36,6 +36,16 @@ function doPost(e) {
     // Open target or create new spreadsheet safely
     const ss = openSpreadsheetOrCreate_(payload);
 
+    // (Optional) Share the newly created sheet with a viewer, if requested.
+    try {
+      const shareEmail = coalesce_(payload, ['shareEmail', 'email'], null);
+      if (shareEmail) {
+        DriveApp.getFileById(ss.getId()).addViewer(shareEmail);
+      }
+    } catch (shareErr) {
+      console.log('Share failed: ' + shareErr);
+    }
+
     // Gather arrays with mild schema flexibility
     const summaryRows = coalesce_(payload, ['summaryRows','summary','summary_list'], []) || [];
     const goodList    = coalesce_(payload, ['goodNumbers','allNumbersGood','valid_numbers'], []) || [];


### PR DESCRIPTION
## Summary
- share new sheet with viewer when `shareEmail` provided

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9bca740108326bd368a3c36eab019