### PR TITLE
Add sample payload script for Apps Script push

### DIFF
--- a/scripts/test-push.js
+++ b/scripts/test-push.js
@@ -1,9 +1,8 @@
 // scripts/test-push.js
 // Smoke test: POST a sample payload to your Apps Script Web App.
-// Loads .env if present but also works when you export GSCRIPT_WEBAPP_URL.
 try { require('dotenv').config(); } catch {}
 
-const { pushToSheets } = require('../src/sheets'); // <-- named export
+const { pushToSheets } = require('../src/sheets');
 
 const EXEC_URL = process.env.GSCRIPT_WEBAPP_URL;
 if (!EXEC_URL) {
@@ -12,22 +11,17 @@ if (!EXEC_URL) {
 }
 
 const payload = {
-  // Ask Apps Script to share the new sheet with this email (optional)
+  // optional: ask Apps Script to share the new sheet with this email
   shareEmail: process.env.REPORT_EMAIL || null,
 
-  // Summary rows accept array or object shape
   summaryRows: [
     ['⭐', 'Doe, John', 120.25, 2, 1],
     { lead: 'Smith, Jane', totalPremium: '$48.00', listedCount: 1, extraPolicyCount: 0 }
   ],
-
-  // Good numbers land in AllNumbers A:B
   goodNumbers: [
     ['John Doe', '555-0101'],
     { name: 'Jane Smith', phone: '555-0202' }
   ],
-
-  // Flagged numbers land in AllNumbers C:E
   flaggedNumbers: [
     ['John Doe', '555-0303', 'DNC'],
     { lead: 'Smith, Jane', number: '555-0404', flag: 'Bad/Disconnected' }


### PR DESCRIPTION
## Summary
- simplify test script for pushing a sample payload to Google Sheets Apps Script

## Testing
- `npm test` *(fails: bash: command not found: npm)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c2f552788326bb71493b8521da99