### PR TITLE
Refine Apps Script push test

### DIFF
--- a/scripts/test-push.js
+++ b/scripts/test-push.js
@@ -1,37 +1,34 @@
-// scripts/test-push.js
-// Tiny smoke test that posts sample data to your Apps Script Web App
-// Reads GSCRIPT_WEBAPP_URL from .env (and supports shell export too).
+// scripts/test-push.js — small smoke test to POST a sample payload to Apps Script
 try { require('dotenv').config(); } catch {}
-
 const { pushToSheets } = require("../src/sheets");
 
 const EXEC_URL = process.env.GSCRIPT_WEBAPP_URL; // must end with /exec
 if (!EXEC_URL) {
-  console.error("Missing GSCRIPT_WEBAPP_URL (set it in .env or export it in your shell)");
+  console.error("GSCRIPT_WEBAPP_URL is missing. Put it in .env or export it in your shell.");
   process.exit(1);
 }
 
 const payload = {
   summaryRows: [
-    ["⭐", "DOE, JOHN", 120.25, 2, 1],
-    { lead: "SMITH, JANE", totalPremium: "$48.00", listedCount: 1, extraPolicyCount: 0 }
+    ["⭐", "Doe, John", 120.25, 2, 1],
+    { lead: "Smith, Jane", totalPremium: "$48.00", listedCount: 1, extraPolicyCount: 0 }
   ],
   goodNumbers: [
-    ["John Doe", "555-0101"],
+    ["John Doe", "555-0181"],
     { name: "Jane Smith", phone: "555-0202" }
   ],
   flaggedNumbers: [
-    ["John Doe", "555-0303", "DNC"],
+    ["John Doe", "555-0830", "DNC"],
     { lead: "Smith, Jane", number: "555-0404", flag: "Bad/Disconnected" }
   ]
 };
 
 pushToSheets(EXEC_URL, payload)
-  .then((out) => {
+  .then(out => {
     console.log(typeof out === "string" ? out : JSON.stringify(out, null, 2));
   })
-  .catch((err) => {
-    console.error("FAILED:", err?.message || err);
+  .catch(err => {
+    console.error("FAILED:", err?.stack || err);
     process.exit(1);
   });
 


### PR DESCRIPTION
## Summary
- adjust test script to send sample data to Apps Script endpoint
- clarify error handling and sample data fields for pushToSheets

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run test:push` (fails: GSCRIPT_WEBAPP_URL is missing. Put it in .env or export it in your shell.)

------
https://chatgpt.com/codex/tasks/task_e_68b9c85546a08326907370ab476e0344