### PR TITLE
chore: guard pushToSheets export

### DIFF
--- a/scripts/test-push.js
+++ b/scripts/test-push.js
@@ -1,6 +1,16 @@
 // scripts/test-push.js — small smoke test to POST a sample payload to Apps Script
 try { require('dotenv').config(); } catch {}
-const { pushToSheets } = require("../src/sheets");
+// Be defensive about the export shape so we always get a callable function.
+const sheetsMod = require('../src/sheets');
+const pushToSheets =
+  (sheetsMod && typeof sheetsMod.pushToSheets === 'function') ? sheetsMod.pushToSheets :
+  (typeof sheetsMod === 'function') ? sheetsMod :
+  (sheetsMod && typeof sheetsMod.default === 'function') ? sheetsMod.default :
+  null;
+if (!pushToSheets) {
+  console.error('Could not find a function export "pushToSheets" from ../src/sheets. Got keys:', sheetsMod && Object.keys(sheetsMod));
+  process.exit(1);
+}
 
 const EXEC_URL = process.env.GSCRIPT_WEBAPP_URL; // must end with /exec
 if (!EXEC_URL) {


### PR DESCRIPTION
## Summary
- defensively resolve `pushToSheets` export in test script

## Testing
- `GSCRIPT_WEBAPP_URL=https://example.com/exec npm test` *(fails: AxiosError: Request failed with status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d3c45ee083269ac2acb69b00d698