### PR TITLE
refactor: clarify Sheets helpers export

### DIFF
--- a/src/sheets.js
+++ b/src/sheets.js
@@ -1,14 +1,7 @@
 "use strict";
-
 const axios = require("axios");
 
-/**
- * Low-level helper: POST a payload directly to the Apps Script Web App.
- * Used by the smoke test (scripts/test-push.js).
- * @param {string} execUrl Full /exec URL
- * @param {object} payload JSON body
- * @returns {Promise<any>} parsed JSON or raw body
- */
+// Low-level helper used by scripts/test-push.js
 async function pushToSheets(execUrl, payload) {
   if (!execUrl) throw new Error("Missing execUrl");
   const res = await axios.post(execUrl, payload, {
@@ -224,5 +217,10 @@ async function createSheetAndShare({ email, result }) {
   return { spreadsheetId: data.spreadsheetId, url: data.url };
 }
 
-module.exports = { pushToSheets, createSheetAndShare };
+// Export BOTH helpers in a single CommonJS export.
+// (Avoid mixing `exports.foo = ...` and `module.exports = ...`.)
+module.exports = {
+  pushToSheets,
+  createSheetAndShare,
+};
 


### PR DESCRIPTION
## Summary
- streamline pushToSheets comment and remove extra whitespace
- unify Sheets helpers under a single `module.exports`

## Testing
- `npm test` *(fails: GSCRIPT_WEBAPP_URL is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ed3023588326bed3b5e31a023b2a