### PR TITLE
Simplify test push script import

### DIFF
--- a/scripts/test-push.js
+++ b/scripts/test-push.js
@@ -1,16 +1,10 @@
 // scripts/test-push.js — small smoke test to POST a sample payload to Apps Script
-try { require('dotenv').config(); } catch {}
-// Be defensive about the export shape so we always get a callable function.
-const sheetsMod = require('../src/sheets');
-const pushToSheets =
-  (sheetsMod && typeof sheetsMod.pushToSheets === 'function') ? sheetsMod.pushToSheets :
-  (typeof sheetsMod === 'function') ? sheetsMod :
-  (sheetsMod && typeof sheetsMod.default === 'function') ? sheetsMod.default :
-  null;
-if (!pushToSheets) {
-  console.error('Could not find a function export "pushToSheets" from ../src/sheets. Got keys:', sheetsMod && Object.keys(sheetsMod));
-  process.exit(1);
-}
+try { require("dotenv").config(); } catch {}
+const mod = require("../src/sheets");
+// Quick sanity check: should show ["pushToSheets","createSheetAndShare"]
+// (Leave this log while debugging; remove later if you want.)
+console.log("exports:", Object.keys(mod));
+const { pushToSheets } = mod;
 
 const EXEC_URL = process.env.GSCRIPT_WEBAPP_URL; // must end with /exec
 if (!EXEC_URL) {


### PR DESCRIPTION
## Summary
- streamline test-push script to import sheets module directly
- add debug log showing exported function names

## Testing
- `GSCRIPT_WEBAPP_URL=http://example.com/exec npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9edb730008326a9be0f97fe13034e