### PR TITLE
feat: support diverse scraper exports

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -7,7 +7,15 @@ import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import { fileURLToPath } from 'node:url';
-import { scrapePlanet } from './scraper.js';
+import * as Scraper from './scraper.js';
+
+const pickScrapeExport = (mod) =>
+  mod.scrapePlanet || mod.default || mod.scrape || mod.run || null;
+
+const scrapePlanet = pickScrapeExport(Scraper);
+if (!scrapePlanet) {
+  throw new Error("[SERVER] Could not find scraper export (expected one of: scrapePlanet, default, scrape, run)");
+}
 import { createSheetAndShare } from './sheets.js';
 import { emit, bus } from './events.js';
 


### PR DESCRIPTION
## Summary
- allow server to pick scraper export from several possible names

## Testing
- `npm test` *(fails: GSCRIPT_WEBAPP_URL is missing from .env)*

------
https://chatgpt.com/codex/tasks/task_e_68be2e1681a48326a5ee50e8c1632717