### PR TITLE
feat: polish live view

### DIFF
--- a/src/public/live.html
+++ b/src/public/live.html
@@ -10,23 +10,28 @@
       --panel:#161b22;
       --text:#d8dee9;
       --muted:#8b95a7;
-      --ok:#58a6ff;         /* info */
-      --lead:#7ee787;       /* lead */
-      --sheet:#f2cc60;      /* sheet */
-      --err:#ff7b72;        /* error */
-      --done:#a78bfa;       /* done */
-      --number:#5ac8fa;     /* numbers */
-      --badge:#f6c177;      /* badge */
-      --pulse:#8b95a7;      /* typing bubble dots */
+
+      /* NEW palette */
+      --ok:#a78bfa;        /* Info = purple */
+      --lead:#3b82f6;      /* Lead = blue */
+      --sheet:#6366f1;     /* Sheet = indigo */
+      --err:#ff7b72;       /* Error = red (unchanged) */
+      --done:#22c55e;      /* Done = green */
+      --number:#14b8a6;    /* Numbers = teal */
+      --badge:#f59e0b;     /* Badge = gold */
+      --pulse:#8b95a7;     /* typing bubble dots */
+
       --chip-bg:#0f141a;
       --chip-br:#223040;
-      --ok-bg:#0a2642;
-      --lead-bg:#0f2414;
-      --sheet-bg:#2a2310;
+
+      /* Type BGs */
+      --ok-bg:#1e1531;        /* purple-ish dark */
+      --lead-bg:#0a1b3a;      /* blue-ish dark */
+      --sheet-bg:#14173a;     /* indigo-ish dark */
       --err-bg:#2a1210;
-      --done-bg:#1f1630;
-      --number-bg:#0b2230;
-      --badge-bg:#2a2212;
+      --done-bg:#0f2414;      /* green-ish dark */
+      --number-bg:#0c1f1d;    /* teal-ish dark */
+      --badge-bg:#2a2212;     /* gold-ish dark */
       --pulse-bg:#12161c;
     }
     *{ box-sizing:border-box; }
@@ -35,18 +40,17 @@
     .bar{ display:flex; align-items:center; gap:10px; margin-bottom:12px; }
     .circle{ width:10px; height:10px; border-radius:50%; background:#22c55e; box-shadow:0 0 12px rgba(34,197,94,.45); }
     .card{ background:var(--panel); border:1px solid #222a36; border-radius:14px; padding:10px; }
-    .legend{ display:flex; gap:8px; margin-left:auto; }
     .pill{ display:inline-flex; align-items:center; gap:6px; padding:2px 10px; border-radius:999px; border:1px solid var(--chip-br); background:var(--chip-bg); color:var(--muted); font-size:12px; line-height:18px; text-transform:capitalize; }
     .pill .dot{ width:6px; height:6px; border-radius:50%; }
 
     /* Per-type coloring */
-    .pill.info   { color:var(--ok);    background:var(--ok-bg);    border-color:rgba(88,166,255,.25) }
-    .pill.lead   { color:var(--lead);  background:var(--lead-bg);  border-color:rgba(126,231,135,.20) }
-    .pill.sheet  { color:var(--sheet); background:var(--sheet-bg); border-color:rgba(242,204,96,.20) }
-    .pill.error  { color:var(--err);   background:var(--err-bg);   border-color:rgba(255,123,114,.20) }
-    .pill.done   { color:var(--done);  background:var(--done-bg);  border-color:rgba(167,139,250,.20) }
-    .pill.numbers{ color:var(--number);background:var(--number-bg);border-color:rgba(90,200,250,.20) }
-    .pill.badge  { color:var(--badge); background:var(--badge-bg); border-color:rgba(246,193,119,.20) }
+    .pill.info   { color:var(--ok);    background:var(--ok-bg);    border-color:rgba(167,139,250,.25) }
+    .pill.lead   { color:var(--lead);  background:var(--lead-bg);  border-color:rgba(59,130,246,.25) }
+    .pill.sheet  { color:var(--sheet); background:var(--sheet-bg); border-color:rgba(99,102,241,.25) }
+    .pill.error  { color:var(--err);   background:var(--err-bg);   border-color:rgba(255,123,114,.25) }
+    .pill.done   { color:var(--done);  background:var(--done-bg);  border-color:rgba(34,197,94,.22) }
+    .pill.numbers{ color:var(--number);background:var(--number-bg);border-color:rgba(20,184,166,.22) }
+    .pill.badge  { color:var(--badge); background:var(--badge-bg); border-color:rgba(245,158,11,.25) }
     .pill.pulse  { color:var(--pulse); background:var(--pulse-bg); border-color:rgba(139,149,167,.20) }
 
     .rows{ display:grid; grid-template-columns: 96px 96px 1fr; gap:0; }
@@ -80,17 +84,8 @@
   <div class="wrap">
     <div class="bar">
       <div class="circle" id="lamp" title="Connected"></div>
-      <div class="status">Connected <span class="state" id="state">connecting…</span></div>
-      <div class="legend">
-        <span class="pill info"><span class="dot" style="background:var(--ok)"></span>info</span>
-        <span class="pill lead"><span class="dot" style="background:var(--lead)"></span>lead</span>
-        <span class="pill sheet"><span class="dot" style="background:var(--sheet)"></span>sheet</span>
-        <span class="pill error"><span class="dot" style="background:var(--err)"></span>error</span>
-        <span class="pill done"><span class="dot" style="background:var(--done)"></span>done</span>
-        <span class="pill numbers"><span class="dot" style="background:var(--number)"></span>numbers</span>
-        <span class="pill badge"><span class="dot" style="background:var(--badge)"></span>badge</span>
-        <!-- pulse pill intentionally removed from legend -->
-      </div>
+      <div class="status">Connected <span class="state" id="state">Live</span></div>
+      <!-- Legend removed by request -->
     </div>
 
     <div class="card">
@@ -131,7 +126,6 @@
 
     function trimPayload(ev){
       const out = {...ev};
-      // normalize msg/message so filters work reliably
       if (!out.msg && out.message) out.msg = out.message;
       delete out.__raw;
       delete out.execUrlPrefix;
@@ -139,7 +133,6 @@
     }
 
     function formatLead(ev){
-      // Want: "NAME (index of total)"
       const name = ev.leadName || ev.lead || 'Lead';
       const idx = (typeof ev.index==='number' ? ev.index : (ev.index?String(ev.index):null));
       const tot = (typeof ev.total==='number' ? ev.total : (ev.total?String(ev.total):null));
@@ -155,9 +148,8 @@
           return formatLead(ev);
 
         case 'numbers': {
-          // show just the name (no "lead=") + counts
+          // Show ONLY counts (no name)
           const p=[];
-          if (ev.leadName) p.push(ev.leadName);
           if ('listedCount' in ev)  p.push(`listed=${ev.listedCount}`);
           if ('extraCount' in ev)   p.push(`extras=${ev.extraCount}`);
           if ('flaggedCount' in ev) p.push(`flagged=${ev.flaggedCount}`);
@@ -216,7 +208,6 @@
         t.innerHTML='<span class="tdot"></span><span class="tdot"></span><span class="tdot"></span>';
         pill.appendChild(t);
       }else{
-        // capitalized via CSS text-transform, but keep a string here
         pill.appendChild(document.createTextNode(type));
       }
       cType.appendChild(pill);
@@ -236,8 +227,9 @@
       if (!payload) return false;
       const m = (payload.msg || payload.message || '').trim();
       if (!m) return false;
-      if (m === 'lead: opening') return true;
+      if (m === 'Lead: opening' || m === 'lead: opening') return true;
       if (/^lead\s+\d+:\s+monthly=/i.test(m)) return true;
+      if (/^hello$/i.test(m)) return true; // hide "hello"
       return false;
     }
 
@@ -258,9 +250,8 @@
       const known=new Set(['info','lead','sheet','error','done','numbers','badge']);
       if (payload.type && known.has(payload.type)) type = payload.type;
 
-      // normalize first, then filter
       const clean = trimPayload(payload);
-      if (type==='info' && shouldHideInfo(clean)) return;
+      if ( (type==='info' || type==='message') && shouldHideInfo(clean)) return;
 
       const msg = friendlyMessage({ type, ...clean });
       addRow(clean.ts || ts, type, msg);
@@ -273,9 +264,9 @@
       es = new EventSource(ENDPOINT,{ withCredentials:false });
 
       es.onopen = () => {
-        setState('ok','connected to /events');
+        setState('ok','Live');           // status text
         backoff = 1000;
-        addRow(now(),'info','connected to /events');
+        addRow(now(),'info','Live');     // initial row text
       };
 
       es.onmessage = routeEvent;


### PR DESCRIPTION
## Summary
- refresh live monitor UI, replacing legend and color palette
- label live connection status and initial log row simply "Live"
- hide trivial "hello" info rows and show only counts in numbers events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be6d0d841c8326a7d177ad6f70c470