### PR TITLE
feat: honor limit from env and request

### DIFF
--- a/scripts/test-e2e.js
+++ b/scripts/test-e2e.js
@@ -3,7 +3,11 @@
 // and exits. Designed to finish quickly with smaller lead count.
 
 const BASE = process.env.BASE_URL || 'http://localhost:8080';
-const MAX  = Number(process.env.E2E_MAX || 10);
+// Resolve run cap from env, with solid defaults.
+// Uses MAX_LEADS first, then MAX_LEADS_DEFAULT, else 200.
+const ENV_LIMIT =
+  Number(process.env.MAX_LEADS ?? process.env.MAX_LEADS_DEFAULT ?? NaN);
+const limit = Number.isFinite(ENV_LIMIT) && ENV_LIMIT > 0 ? ENV_LIMIT : 200;
 const TIMEOUT_MS = Number(process.env.E2E_TIMEOUT_MS || 15 * 60 * 1000);
 
 function parseBlocks(buffer) {
@@ -34,7 +38,7 @@ function parseBlocks(buffer) {
   let processed = 0;
 
   try {
-    const url = `${BASE}/scrape?maxLeads=${encodeURIComponent(MAX)}`;
+    const url = `${BASE}/scrape?limit=${encodeURIComponent(limit)}`;
     const res = await fetch(url, {
       headers: { 'Accept': 'text/event-stream' },
       signal: controller.signal


### PR DESCRIPTION
## Summary
- read lead cap from MAX_LEADS/MAX_LEADS_DEFAULT for e2e tests
- honor limit query/body on server with env fallback and default 200

## Testing
- `npm test` *(fails: GSCRIPT_WEBAPP_URL is missing from .env)*
- `npm run test:e2e` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68be80967b388326bfaaed21a7c70caa