### PR TITLE
feat: add limit controls and full-run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Planet Intake
+
+## Running the scraper
+
+### Smoke run (10 leads)
+Defaults to 10 for fast verification. Override with `--max` or `E2E_MAX_LEADS`:
+```bash
+npm run test:e2e
+# or
+npm run test:e2e -- --max=15
+E2E_MAX_LEADS=15 npm run test:e2e
+```
+
+### Full run (honors .env)
+Uses `MAX_LEADS_DEFAULT` from your `.env` (fallback 200). Override with `--max`:
+```bash
+npm run start:full
+npm run start:full -- --max=50
+```

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test:push": "node scripts/test-push.js",
     "test": "npm run -s test:push",
     "scrape": "node src/scraper.js",
-    "test:e2e": "node scripts/test-e2e.js"
+    "test:e2e": "node scripts/test-e2e.js",
+    "start:full": "node src/server.js --run-full"
   },
   "dependencies": {
     "axios": "^1.11.0",


### PR DESCRIPTION
## Summary
- default e2e smoke tests to 10 leads with CLI/env overrides
- add flexible limit resolution and full-run option to server and scraper
- document smoke vs full runs and provide `start:full` script

## Testing
- `npm test` *(fails: GSCRIPT_WEBAPP_URL is missing from .env)*
- `npm run test:e2e` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68befa96fbc08326b83ac0de014f0faa