### PR TITLE
feat: add SSE event hub with job channel routing

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -1,10 +1,81 @@
-// Lightweight event bus for progress streaming
-import { EventEmitter } from 'events';
-export const bus = new EventEmitter();
+// Simple SSE event hub with optional job-scoped channels.
+// Exports:
+//   - onClientConnect(res, jobId?) -> clientId
+//   - removeClient(clientId)
+//   - emit(type, payload)  // payload may include jobId; if present, only that job’s clients receive it
 
-// Helper to send structured events
-export function emit(type, payload = {}) {
-  bus.emit('evt', { type, ts: Date.now(), ...payload });
+let nextId = 1;
+/** @type {Array<{id:number, res:import('http').ServerResponse, jobId:string|null}>} */
+const CLIENTS = [];
+
+/** Writes a single SSE event to a connected client. */
+function writeEvent(res, type, dataObj) {
+  try {
+    const data = JSON.stringify(dataObj ?? {});
+    res.write(`event: ${type}\n`);
+    res.write(`data: ${data}\n\n`);
+  } catch {
+    // ignore broken pipe
+  }
 }
 
-// bus is imported by server.js to broadcast events over SSE
+/** Add an SSE client; returns clientId. */
+export function onClientConnect(res, jobId = null) {
+  const id = nextId++;
+  CLIENTS.push({ id, res, jobId: jobId || null });
+
+  // Initial SSE lines (optional retry)
+  try {
+    res.write(`retry: 3000\n\n`);
+    writeEvent(res, "info", { msg: "client: subscribed", clientId: id, jobId: jobId || null });
+  } catch {
+    // ignore
+  }
+
+  return id;
+}
+
+/** Remove SSE client by id. */
+export function removeClient(clientId) {
+  const idx = CLIENTS.findIndex((c) => c.id === clientId);
+  if (idx >= 0) {
+    try {
+      CLIENTS[idx].res.end();
+    } catch {
+      // ignore
+    }
+    CLIENTS.splice(idx, 1);
+  }
+}
+
+/**
+ * Emit an event to all clients (or to a specific job channel when payload.jobId is present).
+ * @param {string} type
+ * @param {object} payload
+ */
+export function emit(type, payload = {}) {
+  const targetJob = Object.prototype.hasOwnProperty.call(payload, "jobId")
+    ? payload.jobId
+    : null;
+
+  for (const c of CLIENTS) {
+    // If a jobId is included in the payload, only send to matching job channel.
+    if (targetJob !== null && c.jobId !== targetJob) continue;
+    writeEvent(c.res, type, payload);
+  }
+}
+
+// Optional: Housekeeping/heartbeat (prevents some proxies from closing idle connections)
+const HEARTBEAT_MS = 25000;
+setInterval(() => {
+  for (const c of CLIENTS) {
+    try {
+      c.res.write(`:hb ${Date.now()}\n\n`);
+    } catch {
+      // ignore
+    }
+  }
+}, HEARTBEAT_MS);
+
+// Expose for /status if needed
+global.__SSE_CLIENTS = CLIENTS;


### PR DESCRIPTION
## Summary
- replace event bus with simple SSE hub
- add per-client registration and removal
- support job-scoped event emission and heartbeat

## Testing
- `npm test` *(fails: GSCRIPT_WEBAPP_URL is missing from .env)*

------
https://chatgpt.com/codex/tasks/task_e_68c04c79c674832681fa6df529cf70fc